### PR TITLE
Bugfix: login redirect missing original parameters, mime type not supported

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,6 +59,10 @@
 			<artifactId>spring-boot-starter-web</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>org.apache.commons</groupId>
+			<artifactId>commons-lang3</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>io.github.wimdeblauwe</groupId>
 			<artifactId>htmx-spring-boot</artifactId>
 			<version>3.5.0</version>

--- a/src/main/java/org/cyberelay/oauth2/config/AppConfig.java
+++ b/src/main/java/org/cyberelay/oauth2/config/AppConfig.java
@@ -63,7 +63,7 @@ public class AppConfig {
                 )
                 .formLogin(formLogin -> formLogin
                         .loginPage(EndPoints.LOGIN)
-                        .defaultSuccessUrl(EndPoints.AUTHORIZATION, true) // return to authorization after login
+                        .defaultSuccessUrl(EndPoints.AUTHORIZATION, false)
                 )
                 .logout(logout -> logout
                         .logoutSuccessUrl(EndPoints.LOGIN + "?logout").permitAll()

--- a/src/main/java/org/cyberelay/oauth2/controller/AuthorizationController.java
+++ b/src/main/java/org/cyberelay/oauth2/controller/AuthorizationController.java
@@ -1,11 +1,14 @@
 package org.cyberelay.oauth2.controller;
 
+import org.apache.commons.lang3.StringUtils;
 import org.cyberelay.oauth2.config.EndPoints;
 import org.cyberelay.oauth2.dao.ClientRepository;
+import org.cyberelay.oauth2.model.Client;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.oauth2.server.authorization.OAuth2AuthorizationService;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -15,8 +18,6 @@ import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 
-import java.security.Principal;
-
 @Controller
 @RequestMapping(EndPoints.AUTHORIZATION)
 public class AuthorizationController {
@@ -25,10 +26,14 @@ public class AuthorizationController {
     private final ClientRepository registeredClientRepository;
     private final OAuth2AuthorizationService authorizationService;
 
+    private final Client defaultClient;
+
     public AuthorizationController(ClientRepository registeredClientRepository,
-                                   OAuth2AuthorizationService authorizationService) {
+                                   OAuth2AuthorizationService authorizationService,
+                                   @Qualifier("DEFAULT_CLIENT") Client defaultClient) {
         this.registeredClientRepository = registeredClientRepository;
         this.authorizationService = authorizationService;
+        this.defaultClient = defaultClient;
     }
 
     public record AuthorizeRequest(String client_id,
@@ -39,31 +44,48 @@ public class AuthorizationController {
                                    String code_challenge,
                                    String code_challenge_method,
                                    String state) {
+        public AuthorizeRequest withClientId(String client_id) {
+            return new AuthorizeRequest(
+                    client_id,
+                    this.redirect_uri,
+                    this.response_type,
+                    this.response_mode,
+                    this.scope,
+                    this.code_challenge,
+                    this.code_challenge_method,
+                    this.state
+            );
+        }
     }
 
     @GetMapping
-    public String authorize(@ModelAttribute AuthorizeRequest request,
-                            Model model,
-                            @AuthenticationPrincipal Authentication principal) {
-        var client = registeredClientRepository.findByClientId(request.client_id);
-
-        if (client.isEmpty()) {
-            LOG.warn("Authorization request has no client_id");
-            //throw new IllegalArgumentException("Invalid client_id");
+    public String authorize(@ModelAttribute AuthorizeRequest request, Model model) {
+        if (StringUtils.isEmpty(request.client_id)) {
+            // Customization for the test kit which has no client ID
+            LOG.warn("Authorization request has no client_id, default client ID is used");
+            request = request.withClientId(defaultClient.getClientId());
         }
+
+        if (registeredClientRepository.findByClientId(request.client_id).isEmpty()) {
+            throw new IllegalArgumentException("Invalid client_id");
+        }
+
+        // Get the current login user info
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        LOG.info("authentication: {}", authentication);
 
         model.addAttribute("clientId", request.client_id);
         model.addAttribute("redirectUri", request.redirect_uri);
         model.addAttribute("responseType", request.response_type);
         model.addAttribute("scope", request.scope);
         model.addAttribute("state", request.state);
-        model.addAttribute("principalName", principal == null ? null : principal.getName());
+        model.addAttribute("principalName", authentication.getName());
 
         return "authorize";
     }
 
     @PostMapping
-    public String approveAuthorization(@RequestBody AuthorizeRequest request, Principal principal) {
+    public String approveAuthorization(@RequestBody AuthorizeRequest request) {
         // Custom logic to approve the authorization request.
         // Redirecting to the provided redirect URI after successful authorization
         String redirectUrl = request.redirect_uri + "?code=sample_auth_code&state=" + request.state;

--- a/src/main/java/org/cyberelay/oauth2/controller/AuthorizationController.java
+++ b/src/main/java/org/cyberelay/oauth2/controller/AuthorizationController.java
@@ -13,7 +13,6 @@ import org.springframework.security.oauth2.server.authorization.OAuth2Authorizat
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
-import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;

--- a/src/main/java/org/cyberelay/oauth2/controller/AuthorizationController.java
+++ b/src/main/java/org/cyberelay/oauth2/controller/AuthorizationController.java
@@ -85,7 +85,7 @@ public class AuthorizationController {
     }
 
     @PostMapping
-    public String approveAuthorization(@RequestBody AuthorizeRequest request) {
+    public String approveAuthorization(@ModelAttribute AuthorizeRequest request) {
         // Custom logic to approve the authorization request.
         // Redirecting to the provided redirect URI after successful authorization
         String redirectUrl = request.redirect_uri + "?code=sample_auth_code&state=" + request.state;

--- a/src/main/java/org/cyberelay/oauth2/error/GlobalExceptionHandler.java
+++ b/src/main/java/org/cyberelay/oauth2/error/GlobalExceptionHandler.java
@@ -1,5 +1,7 @@
 package org.cyberelay.oauth2.error;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.ErrorResponse;
@@ -11,6 +13,7 @@ import java.util.NoSuchElementException;
 
 @ControllerAdvice
 public class GlobalExceptionHandler {
+    private static final Logger LOG = LoggerFactory.getLogger(GlobalExceptionHandler.class);
 
     @ExceptionHandler(NoSuchElementException.class)
     public ResponseEntity<ErrorResponse> handleNoSuchElementException(NoSuchElementException ex, WebRequest request) {
@@ -36,6 +39,7 @@ public class GlobalExceptionHandler {
                 .builder(ex, status, LocalDateTime.now().toString())
                 .detail(detail)
                 .build();
+        LOG.error("Api error: " + detail, ex);
         return new ResponseEntity<>(errorResponse, status);
     }
 }

--- a/src/main/java/org/cyberelay/oauth2/model/Client.java
+++ b/src/main/java/org/cyberelay/oauth2/model/Client.java
@@ -6,6 +6,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import jakarta.persistence.Transient;
 import org.springframework.security.oauth2.core.AuthorizationGrantType;
 import org.springframework.security.oauth2.core.ClientAuthenticationMethod;
 import org.springframework.security.oauth2.server.authorization.client.RegisteredClient;
@@ -23,6 +24,9 @@ public class Client {
 
     @Column
     private String clientSecret;
+
+    @Transient
+    private String decodedClientSecret;
 
     @Column
     private String redirectUris;
@@ -95,7 +99,8 @@ public class Client {
             builder.clientSecret(template.clientSecret)
                     .clientId(template.clientId)
                     .redirectUris(template.redirectUris)
-                    .scopes(template.scopes);
+                    .scopes(template.scopes)
+                    .decodedClientSecret(template.decodedClientSecret);
         }
 
         return builder;
@@ -127,12 +132,19 @@ public class Client {
             return this;
         }
 
+        public Builder decodedClientSecret(String decodedSecret) {
+            template.decodedClientSecret = decodedSecret;
+            return this;
+        }
+
         public Client build() {
             var newClient = new Client();
             newClient.clientId = template.clientId;
             newClient.clientSecret = template.clientSecret;
             newClient.redirectUris = template.redirectUris;
             newClient.scopes = template.scopes;
+            newClient.decodedClientSecret = template.decodedClientSecret;
+
             return newClient;
         }
     }


### PR DESCRIPTION
## Summary
- Feature: Use default client if absent
- Bugfix: missing original request parameters for the redirect page after user login
- Feature: add decoded client secret into Client
- Bugfix: `application/x-www-form-urlencoded` not supported